### PR TITLE
README: Add wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Parse and upload BioSample XML data into a PostgreSQL database using AWS Lambdas.
 
+## Documentation
+
+See [wiki](https://github.com/serratus-bio/biosample-sql/wiki).
+
 ## Database
 
 See https://github.com/ababaian/serratus/wiki/Serratus-SQL-Database-Management


### PR DESCRIPTION
There are scattered notes in the wiki. Ideally most of that content should live in the README for better visibility, but having a link to where they are at the moment is better than nothing.