### PR TITLE
Fix checks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7.9
+        python-version: 3.7
     - name: Install dependencies
       run: |
         pip install flake8


### PR DESCRIPTION
Python 3.7.9 is no longer available via actions/setup-python, but this code should work with any Python 3.7 patch version.